### PR TITLE
Fix Clean All Flag Handling

### DIFF
--- a/jal/db/db.py
+++ b/jal/db/db.py
@@ -142,7 +142,7 @@ class JalDB:
             error = self.run_sql_script(self.get_app_path() + Setup.INIT_SCRIPT_PATH)
             if error.code != JalDBError.NoError:
                 return error
-        if self._read("SELECT value FROM settings WHERE name='CleanDB'") == 1:
+        if self._read("SELECT value FROM settings WHERE name='CleanDB'") == '2':
             db.close()
             os.remove(self.get_db_path())
             db.open()

--- a/jal/widgets/main_window.py
+++ b/jal/widgets/main_window.py
@@ -185,7 +185,7 @@ class MainWindow(QMainWindow):
                                  self.tr("All data will be deleted. The actions can't be undone.\nAre you sure?"),
                                  QMessageBox.Yes, QMessageBox.No) == QMessageBox.No:
             return
-        JalSettings().setValue("CleanDB", 1)
+        JalSettings().setValue("CleanDB", 2)
         QMessageBox().information(self, self.tr("Restart required"),
                                   self.tr("Database will be removed at next JAL start.\n"
                                           "Application will be terminated now."),


### PR DESCRIPTION
### Problem Description

- The "Clean All" functionality currently sets the CleanDB flag to 1 using JalSettings.setValue().
- On startup, the code reads this value using JalDB._read(), which returns a string instead of a number, causing the cleaning logic to fail.

### Critical Note

Some users may already have CleanDB = 1 set in their databases, as they may have previously used the "Clean All" action.  
It is crucial to change the flag value used for triggering cleanup to a new value. Otherwise, after fixing the type mismatch, users with an old CleanDB = 1 flag could have their databases unexpectedly cleared after the update.
